### PR TITLE
Improve SO_LINGER support

### DIFF
--- a/client.pl
+++ b/client.pl
@@ -145,6 +145,11 @@ while (<STDIN>) {
         print "INVALID\n" if $shutdown > 2 && $debug;
         next;
     }
+    if (/linge?r\s*(\d+)/a) {
+        my $linger_timeout = $1;
+        $socket->setsockopt(SOL_SOCKET, SO_LINGER, pack("II", 1, $linger_timeout));
+        next;
+    }
     if (/ti?me?out(\s*[\d.]*)?/a) {
         my $v = ltrim($1);
         if ($timeout_available) {


### PR DESCRIPTION
Allow setting the SO_LINGER socket option in the client during regular operation, to better mock timeouts that will force a reset.

Also allow for not setting the SO_LINGER socket option in the fork server, or use a different value for the timeout, which should also prevent close/shutdown to send RST instead of FIN.

Note that SO_LINGER behaviour is not standarized and might behave differently if not using Linux